### PR TITLE
Movements without accountable

### DIFF
--- a/app/models/concerns/ledgerizer_tenant.rb
+++ b/app/models/concerns/ledgerizer_tenant.rb
@@ -40,7 +40,6 @@ module LedgerizerTenant
 
     def find_or_create_account_from_executable_movement!(movement)
       accounts.find_or_create_by!(
-        tenant: self,
         accountable: movement.accountable,
         name: movement.account_name,
         currency: format_to_upcase(movement.base_currency),

--- a/app/models/concerns/ledgerizer_tenant.rb
+++ b/app/models/concerns/ledgerizer_tenant.rb
@@ -40,6 +40,7 @@ module LedgerizerTenant
 
     def find_or_create_account_from_executable_movement!(movement)
       accounts.find_or_create_by!(
+        tenant: self,
         accountable: movement.accountable,
         name: movement.account_name,
         currency: format_to_upcase(movement.base_currency),

--- a/app/models/ledgerizer/account.rb
+++ b/app/models/ledgerizer/account.rb
@@ -5,7 +5,7 @@ module Ledgerizer
     include LedgerizerLinesRelated
 
     belongs_to :tenant, polymorphic: true
-    belongs_to :accountable, polymorphic: true
+    belongs_to :accountable, polymorphic: true, optional: true
     has_many :lines, dependent: :destroy
 
     enumerize :account_type, in: Ledgerizer::Definition::Account::TYPES,

--- a/lib/ledgerizer/definition/dsl.rb
+++ b/lib/ledgerizer/definition/dsl.rb
@@ -48,7 +48,7 @@ module Ledgerizer
           @current_entry = nil
         end
 
-        def debit(account:, accountable:)
+        def debit(account:, accountable: nil)
           in_context do
             @current_tenant.add_movement(
               movement_type: :debit,

--- a/lib/ledgerizer/definition/entry.rb
+++ b/lib/ledgerizer/definition/entry.rb
@@ -22,9 +22,7 @@ module Ledgerizer
       end
 
       def add_movement(movement_type:, account:, accountable:)
-        ar_accountable = format_to_symbol_identifier(accountable)
-        validate_active_record_model_name!(ar_accountable, "accountable")
-        validate_unique_account!(movement_type, account.name, ar_accountable)
+        ar_accountable = find_ar_accountable(movement_type, account.name, accountable)
 
         Ledgerizer::Definition::Movement.new(
           account: account,
@@ -40,6 +38,18 @@ module Ledgerizer
       end
 
       private
+
+      def find_ar_accountable(movement_type, account_name, accountable)
+        ar_accountable = nil
+
+        if !accountable.blank?
+          ar_accountable = format_to_symbol_identifier(accountable)
+          validate_active_record_model_name!(ar_accountable, "accountable")
+        end
+
+        validate_unique_account!(movement_type, account_name, ar_accountable)
+        ar_accountable
+      end
 
       def infer_model_name(value)
         return format_model_to_sym(value) if value.is_a?(ActiveRecord::Base)

--- a/lib/ledgerizer/definition/movement.rb
+++ b/lib/ledgerizer/definition/movement.rb
@@ -12,11 +12,19 @@ module Ledgerizer
       def initialize(account:, accountable:, movement_type:)
         @account = account
         @movement_type = format_to_symbol_identifier(movement_type)
-        @accountable = format_to_symbol_identifier(accountable)
+        @accountable = format_to_symbol_identifier(accountable) if accountable
       end
 
       def accountable_class
+        return unless accountable
+
         format_sym_to_model(accountable)
+      end
+
+      def accountable_string_class
+        return unless accountable
+
+        accountable_class.to_s
       end
     end
   end

--- a/lib/ledgerizer/execution/dsl.rb
+++ b/lib/ledgerizer/execution/dsl.rb
@@ -38,7 +38,7 @@ module Ledgerizer
           @executor = nil
         end
 
-        def debit(account:, accountable:, amount:)
+        def debit(account:, amount:, accountable: nil)
           in_context do
             @executor.add_movement(
               movement_type: :debit,
@@ -49,7 +49,7 @@ module Ledgerizer
           end
         end
 
-        def credit(account:, accountable:, amount:)
+        def credit(account:, amount:, accountable: nil)
           in_context do
             @executor.add_movement(
               movement_type: :credit,

--- a/lib/ledgerizer/execution/entry.rb
+++ b/lib/ledgerizer/execution/entry.rb
@@ -51,7 +51,7 @@ module Ledgerizer
           groups = amounts_grouped_by_accountable_and_currency(entry, movement_definition)
           groups.each do |accountabe_data, amount_cents|
             accountable_id, currency = accountabe_data
-            accountable = movement_definition.accountable_class.find(accountable_id)
+            accountable = movement_definition.accountable_class&.find(accountable_id)
 
             block.call(
               accountable: accountable,
@@ -75,7 +75,7 @@ module Ledgerizer
           tenant: entry.tenant,
           entry_code: code,
           document: entry.document,
-          accountable_type: movement_definition.accountable_class.to_s,
+          accountable_type: movement_definition.accountable_string_class,
           account_name: movement_definition.account_name
         )
       end
@@ -89,7 +89,7 @@ module Ledgerizer
       end
 
       def get_movement_definition!(movement_type, account_name, accountable)
-        validate_active_record_instance!(accountable, "accountable")
+        validate_active_record_instance!(accountable, "accountable") if accountable
         movement_definition = entry_definition.find_movement(
           movement_type: movement_type,
           account_name: account_name,

--- a/spec/dummy/spec/lib/execution/dsl_spec.rb
+++ b/spec/dummy/spec/lib/execution/dsl_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Ledgerizer::Execution::Dsl do
         credit(account: :account2, accountable: :user)
         credit(account: :account3, accountable: :user)
       end
+
+      entry(:entry3, document: :user) do
+        debit(account: :account1, accountable: :user)
+        credit(account: :account2)
+      end
     end
   end
 
@@ -121,6 +126,45 @@ RSpec.describe Ledgerizer::Execution::Dsl do
 
       before do
         LedgerizerTestExecution.new(debit: debit_data, credit: credit_data).execute_entry1_entry(
+          tenant: tenant, document: document, date: date
+        ) do
+          debit(data[:debit])
+          credit(data[:credit])
+        end
+      end
+
+      it { expect(tenant).to have_ledger_entry(expected_entry) }
+      it { expect(Ledgerizer::Entry.last).to have_ledger_line(debit_data) }
+      it { expect(Ledgerizer::Entry.last).to have_ledger_line(credit_data) }
+    end
+
+    context "with movement without accountable" do
+      let(:expected_entry) do
+        {
+          entry_code: :entry3,
+          entry_date: date,
+          document: document
+        }
+      end
+
+      let(:debit_data) do
+        {
+          account: :account1,
+          accountable: create(:user),
+          amount: clp(1)
+        }
+      end
+
+      let(:credit_data) do
+        {
+          account: :account2,
+          accountable: nil,
+          amount: clp(1)
+        }
+      end
+
+      before do
+        LedgerizerTestExecution.new(debit: debit_data, credit: credit_data).execute_entry3_entry(
           tenant: tenant, document: document, date: date
         ) do
           debit(data[:debit])

--- a/spec/dummy/spec/models/ledgerizer/account_spec.rb
+++ b/spec/dummy/spec/models/ledgerizer/account_spec.rb
@@ -8,7 +8,7 @@ module Ledgerizer
 
     describe "associations" do
       it { is_expected.to belong_to(:tenant) }
-      it { is_expected.to belong_to(:accountable) }
+      it { is_expected.to belong_to(:accountable).optional }
       it { is_expected.to have_many(:lines).dependent(:destroy) }
     end
 

--- a/spec/dummy/spec/support/shared_examples/definition_dsl_movement.rb
+++ b/spec/dummy/spec/support/shared_examples/definition_dsl_movement.rb
@@ -60,6 +60,30 @@ shared_examples 'definition dsl movement' do |type|
       it { expect(LedgerizerTestDefinition).to have_ledger_movement_definition(expected) }
     end
 
+    context "with no accountable" do
+      let_definition_class do
+        tenant('portfolio') do
+          asset(:cash)
+
+          entry(:deposit, document: :portfolio) do
+            send(type, account: :cash)
+          end
+        end
+      end
+
+      let(:expected) do
+        {
+          tenant_class: :portfolio,
+          entry_code: :deposit,
+          movement_type: type,
+          account: :cash,
+          accountable: nil
+        }
+      end
+
+      it { expect(LedgerizerTestDefinition).to have_ledger_movement_definition(expected) }
+    end
+
     context "with multiple movements" do
       let_definition_class do
         tenant('portfolio') do


### PR DESCRIPTION
Tenía esta configuración:

```ruby
Ledgerizer.setup do |conf|
  conf.tenant(:subsidiary, currency: :clp) do
    conf.asset :bank
    conf.liability :user_funds_custody

    conf.entry :user_deposit, document: :statement_line do
      conf.debit account: :bank, accountable: :reserve_account
      conf.credit account: :user_funds_custody, accountable: :subsidiary
    end
  end
end
```

con `subsidiary` como tenant y además `accountable`. Esto en la práctica no se puede hacer porque el modelo `Subsidiary` estaba incluyendo 2 concern: `LedgerizerTenant` y `LedgerizerAccountable` que implementan los métodos `accounts` y `lines` entonces, al incluir los dos, uno estaba sobrescribiendo los métodos del otro.

El cambio en este PR es la posibilidad de no poner un `accountable`

```ruby
Ledgerizer.setup do |conf|
  conf.tenant(:subsidiary, currency: :clp) do
    conf.asset :bank
    conf.liability :user_funds_custody

    conf.entry :user_deposit, document: :statement_line do
      conf.debit account: :bank, accountable: :reserve_account
      conf.credit account: :user_funds_custody
    end
  end
end
```

que termina siendo equivalente a asignarle el tenant como accountable a un movimiento.

