### PR TITLE
Make it compatible with Rails 6

### DIFF
--- a/lib/ledgerizer/execution/entry_executor.rb
+++ b/lib/ledgerizer/execution/entry_executor.rb
@@ -48,7 +48,7 @@ module Ledgerizer
         end
 
         last_account_line = update_related_account_lines_balances(locked_account)
-        locked_account.update_attributes(
+        locked_account.update(
           balance_cents: last_account_line.balance_cents,
           balance_currency: last_account_line.balance_currency
         )


### PR DESCRIPTION
I just replace a place where `update_attributes` was used with `update` because the former is deprecated in Rails 6.